### PR TITLE
Added missing "lxml" to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyQt5
 regipy
+lxml


### PR DESCRIPTION
On Windows, `lxml` is not part of the default Python installation, and thus also doesn't automatically get installed into the venv.